### PR TITLE
Fix js comment colors

### DIFF
--- a/styles/languages/js.less
+++ b/styles/languages/js.less
@@ -19,7 +19,7 @@
   .syntax--property {
     color: @property;
   }
-  .syntax--delimiter, .syntax--punctuation:not(.syntax--embedded) {
+  .syntax--delimiter, .syntax--punctuation:not(.syntax--embedded):not(.syntax--comment) {
     color: @meta !important;
   }
   .syntax--punctuation.syntax--embedded {


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/8714775/26531682/00674e3e-43ee-11e7-85e0-799c9bbec660.jpg)

After:
![after](https://cloud.githubusercontent.com/assets/8714775/26531680/fb71b072-43ed-11e7-8278-4f89fab18619.jpg)


Fixes #19 